### PR TITLE
add property to allow using a custom supabase API-URL

### DIFF
--- a/src/main/kotlin/de/tschuehly/htmx/spring/supabase/auth/SupabaseAutoConfiguration.kt
+++ b/src/main/kotlin/de/tschuehly/htmx/spring/supabase/auth/SupabaseAutoConfiguration.kt
@@ -58,7 +58,7 @@ class SupabaseAutoConfiguration(
     @ConditionalOnMissingBean
     fun supabaseClient(supabaseProperties: SupabaseProperties): Auth {
         val supabase = createSupabaseClient(
-            supabaseUrl = "https://${supabaseProperties.projectId}.supabase.co",
+            supabaseUrl = supabaseProperties.url?: "https://${supabaseProperties.projectId}.supabase.co",
             supabaseKey = supabaseProperties.anonKey
         ) {
             install(Auth) {

--- a/src/main/kotlin/de/tschuehly/htmx/spring/supabase/auth/config/SupabaseProperties.kt
+++ b/src/main/kotlin/de/tschuehly/htmx/spring/supabase/auth/config/SupabaseProperties.kt
@@ -6,6 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("supabase")
 class SupabaseProperties(
     val projectId: String,
+    val url: String?,
     val anonKey: String,
     val jwtSecret: String?,
     val database: Database? = null,

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -14,6 +14,12 @@
       "sourceType": "de.tschuehly.htmx.spring.supabase.auth.config.SupabaseProperties"
     },
     {
+      "name": "supabase.url",
+      "type": "java.lang.String",
+      "description": "The API-URL of your supabase instance (leave empty to use default: https://$projectId.supabase.co)",
+      "sourceType": "de.tschuehly.htmx.spring.supabase.auth.config.SupabaseProperties"
+    },
+    {
       "name": "supabase.anonKey",
       "type": "java.lang.String",
       "description": "The anon project api key, found at Project settings - API",


### PR DESCRIPTION
Hey @tschuehly, first of all thank you for the great work.

I created this PR because when using a local supabase instance (info [here](https://supabase.com/docs/guides/cli/local-development)), the `auth` feature still uses the custom remote supabase domain (`https://$projectId.supabase.co`).

Please feel free to edit or suggest changes.